### PR TITLE
add support for osx, avoid setting global variables

### DIFF
--- a/nerdtree_plugin/execute_menuitem.vim
+++ b/nerdtree_plugin/execute_menuitem.vim
@@ -10,7 +10,8 @@ if exists("g:loaded_nerdtree_shell_exec_menuitem")
 endif
 
 let g:loaded_nerdtree_shell_exec_menuitem = 1
-let g:haskdeinit = system("ps -e") =~ 'kdeinit'
+let s:haskdeinit = system("ps -e") =~ 'kdeinit'
+let s:hasdarwin = system("uname -s") =~ 'Darwin'
 
 call NERDTreeAddMenuItem({
       \ 'text': 'e(x)ecute',
@@ -27,11 +28,14 @@ function! NERDTreeExecute()
     let args = shellescape(path,1)." > /dev/null"
   end
 
-  if has("unix") && executable("gnome-open") && !g:haskdeinit
+  if has("unix") && executable("gnome-open") && !s:haskdeinit
     exe "silent !gnome-open ".args
     let ret= v:shell_error
-  elseif has("unix") && executable("kde-open") && g:haskdeinit
+  elseif has("unix") && executable("kde-open") && s:haskdeinit
     exe "silent !kde-open ".args
+    let ret= v:shell_error
+  elseif has("unix") && executable("open") && s:hasdarwin
+    exe "silent !open ".args
     let ret= v:shell_error
   elseif has("win32") || has("win64")
     exe "silent !start explorer ".shellescape(path,1)


### PR DESCRIPTION
This adds support for the darwin "open" command which works equivalently to the other two.  I also changed the platform indicator variables to be local to the script, since they probably aren't meant to be exported.
